### PR TITLE
Bump for release v3.0.1

### DIFF
--- a/lib/recog/version.rb
+++ b/lib/recog/version.rb
@@ -1,3 +1,3 @@
 module Recog
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end


### PR DESCRIPTION
## Description
Bumps `lib/recog/version.rb` for release v3.0.1. A mistake was made and v3.0.0 was built without the recog content.


## Motivation and Context
Prepare for v3.0.1 gem release.


## How Has This Been Tested?
* `rake tests`
* `gem build recog.gemspec`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
