### PR TITLE
Add match reporter support for JSON output

### DIFF
--- a/lib/recog/match_reporter.rb
+++ b/lib/recog/match_reporter.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Recog
 class MatchReporter
   attr_reader :formatter
@@ -24,14 +26,46 @@ class MatchReporter
     @line_count += 1
   end
 
-  def match(text)
+  def match(match_data)
     @match_count += 1
-    formatter.success_message(text)
+    if @options.json_format
+      # remove data field from all matches and promote to a top-level field
+      data_field = match_data[0]["data"]
+      match_data.each { |h| h.delete("data") }
+      new_object = {
+        'data' => data_field,
+      }
+
+      if @options.multi_match
+        new_object['matches'] = match_data
+      else
+        new_object['match'] = match_data[0]
+      end
+      msg = new_object.to_json
+    else
+      match_prefix = match_data.size > 1 ? 'MATCHES' : 'MATCH'
+      msg = "#{match_prefix}: #{match_data.map(&:inspect).join(',')}"
+    end
+    formatter.success_message("#{msg}")
   end
 
   def failure(text)
     @fail_count += 1
-    formatter.failure_message(text)
+    if @options.json_format
+      new_object = {
+        'data' => text,
+        'match_failure' => true
+      }
+      if @options.multi_match
+        new_object['matches'] = nil
+      else
+        new_object['match'] = nil
+      end
+      msg = new_object.to_json
+    else
+      msg = "FAIL: #{text}"
+    end
+    formatter.failure_message("#{msg}")
   end
 
   def print_summary

--- a/lib/recog/matcher.rb
+++ b/lib/recog/matcher.rb
@@ -29,26 +29,21 @@ class Matcher
         line = line.to_s.unpack("C*").pack("C*").strip.gsub(/\\[rn]/, '')
         found_extractions = false
 
-        all_extractions = []
+        extraction_data = []
         fingerprints.each do |fp|
           extractions = fp.match(line)
           if extractions
             found_extractions = true
             extractions['data'] = line
-            if multi_match
-              all_extractions << extractions
-            else
-              reporter.match "MATCH: #{extractions.inspect}"
-              break
-            end
+            extraction_data << extractions
+            break unless multi_match
           end
         end
 
         if found_extractions
-          match_prefix = all_extractions.size > 1 ? 'MATCHES' : 'MATCH'
-          reporter.match "#{match_prefix}: #{all_extractions.map(&:inspect).join(',')}" if multi_match
+          reporter.match extraction_data
         else
-          reporter.failure "FAIL: #{line}"
+          reporter.failure line
         end
 
         if reporter.stop?


### PR DESCRIPTION
## Description
Adds `MatchReporter` support for JSON output.


## Motivation and Context
Increase the usability of `recog_match` in command pipelines since JSON is easier to parse with other tools such as `jq`.


## How Has This Been Tested?
* Updated `MatchReporter` spec test to handle interface change and added new tests for JSON format.
* `rake tests`

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
