### PR TITLE
CI Workflow: add Ruby 3.1 and make lower JRuby version flexible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', 'jruby-9.2.20.1', 'jruby']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', 'jruby-9.2', 'jruby']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Description
Updates the GitHub CI workflow `.github/workflows/ci.yml` to include Ruby `3.1`, and modifies the lower JRuby version making it flexible should any future `9.2.x` versions be released.


## Motivation and Context
To keep CI testing current with new versions.


## How Has This Been Tested?
Changes confirmed by inspecting the GitHub actions run on this branch and PR.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
