### PR TITLE
Update workflow action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', 'jruby-9.2', 'jruby']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Set up Ruby


### PR DESCRIPTION
## Description
Updates the GitHub CI (`.github/workflows/ci.yml`) workflow action versions after I observed the following warning when inspecting our action's output.

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout

Updates:
* `actions/checkout@v2` to `actions/checkout@v3`


## Motivation and Context
Keeping GitHub workflows up-to-date.


## How Has This Been Tested?
Changes confirmed by inspecting the GitHub actions run on this branch and PR.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
