### PR TITLE
Bump version to 3.1.29

### DIFF
--- a/lib/recog/version.rb
+++ b/lib/recog/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Recog
-  VERSION = '3.1.28'
+  VERSION = '3.1.29'
 end


### PR DESCRIPTION
## Summary

Version `3.1.28` is already published to RubyGems and the pipeline was failing with:

```
Repushing of gem versions is not allowed.
Please bump the version number and push a new different release.
```

This bumps `VERSION` to `3.1.29` so the publish pipeline can succeed.

> [!NOTE]
> This PR was created by AI (GitHub Copilot CLI).